### PR TITLE
Tests added

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ $ meteor add arggh:teleport
 </template>
 ```
 
+## Run the tests
+
+If you want to contribute and improve the package, make sure to run the tests.
+Clone the package and run the following command:
+
+```bash
+$ TEST_WATCH=1 meteor test-packages ./ --driver-package meteortesting:mocha
+```
+
 ## License
 
 Teleport is released under the [MIT License](http://opensource.org/licenses/MIT).

--- a/package.js
+++ b/package.js
@@ -21,12 +21,14 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function (api) {
-  api.use('ecmascript');
-  api.use('meteor');
-  api.use('check');
-  api.use('blaze')
-  api.use('templating')
-  api.use('meteortesting:mocha');
-  api.use('practicalmeteor:chai');
-  api.use('arggh:teleport');
+  api.use([
+    'ecmascript',
+    'meteor',
+    'check',
+    'blaze',
+    'templating',
+    'meteortesting:mocha',
+    'practicalmeteor:chai',
+    'arggh:teleport']);
+  api.mainModule('src/teleport.tests.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -19,3 +19,14 @@ Package.onUse(function(api) {
     'src/teleport.js'
   ], 'client');
 });
+
+Package.onTest(function (api) {
+  api.use('ecmascript');
+  api.use('meteor');
+  api.use('check');
+  api.use('blaze')
+  api.use('templating')
+  api.use('meteortesting:mocha');
+  api.use('practicalmeteor:chai');
+  api.use('arggh:teleport');
+});

--- a/package.js
+++ b/package.js
@@ -24,7 +24,6 @@ Package.onTest(function (api) {
   api.use([
     'ecmascript',
     'meteor',
-    'check',
     'blaze',
     'templating',
     'meteortesting:mocha',

--- a/src/helpers.tests.js
+++ b/src/helpers.tests.js
@@ -1,0 +1,27 @@
+/* global document */
+
+// TODO -- this should probably be some kind of test package that people use
+
+import { _ } from 'meteor/underscore';
+import { Template } from 'meteor/templating';
+import { Blaze } from 'meteor/blaze';
+import { Tracker } from 'meteor/tracker';
+
+const withDiv = function withDiv(callback) {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  try {
+    callback(el);
+  } finally {
+    document.body.removeChild(el);
+  }
+};
+
+export const withRenderedTemplate = function withRenderedTemplate(template, data, callback) {
+  withDiv((el) => {
+    const ourTemplate = _.isString(template) ? Template[template] : template;
+    Blaze.renderWithData(ourTemplate, data, el);
+    Tracker.flush();
+    callback(el);
+  });
+};

--- a/src/teleport.tests.html
+++ b/src/teleport.tests.html
@@ -1,0 +1,3 @@
+<template name="test">
+	<div id="test-target-id"></div>
+</template>

--- a/src/teleport.tests.html
+++ b/src/teleport.tests.html
@@ -1,3 +1,5 @@
-<template name="test">
+<template name="dest">
+	{{#Teleport destination=destination}}
 	<div id="test-target-id"></div>
+	{{/Teleport}}
 </template>

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -45,7 +45,7 @@ describe('teleport to render destination', function () {
     })
   });
 
-  it ('renders a Temaplte in the document.body as default destination', function (done) {
+  it ('renders a Template in the document.body as default destination', function (done) {
     withRenderedTemplate('dest', {}, (el) => {
       isBeamed(el, 'body', '#test-target-id')
       done()

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+import { assert } from 'meteor/practicalmeteor:chai';
+import { withRenderedTemplate } from './helpers.tests';
+import './teleport.tests.html';
+
+describe('destination', function () {
+  
+  it ('renders a Template with a given target node as destination', function () {
+    assert.fail();
+  });
+
+  it ('renders a Template with a given CSS selector as destination', function () {
+    assert.fail();
+  });
+
+  it ('renders a Temaplte in the document.body as default destination', function () {
+    assert.fail();
+  });
+});
+
+

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -1,21 +1,54 @@
 /* eslint-env mocha */
+import { Template } from 'meteor/templating';
 import { assert } from 'meteor/practicalmeteor:chai';
 import { withRenderedTemplate } from './helpers.tests';
 import './teleport.tests.html';
 
-describe('destination', function () {
-  
-  it ('renders a Template with a given target node as destination', function () {
-    assert.fail();
+const isBeamed = (oldTarget, newTarget, selector) => {
+  assert.equal($(oldTarget).find(selector).length, 0)
+  assert.equal($(newTarget).find(selector).length, 1)
+}
+
+describe('teleport to render destination', function () {
+
+  beforeEach(function () {
+    Template.registerHelper('_', key => key);
   });
 
-  it ('renders a Template with a given CSS selector as destination', function () {
-    assert.fail();
+  afterEach(function () {
+    Template.deregisterHelper('_');
   });
 
-  it ('renders a Temaplte in the document.body as default destination', function () {
-    assert.fail();
+  it ('renders a Template with a given target node as destination', function (done) {
+    // let's append a new div to the body
+    // which will act as our render target
+    const targetNode = $('<div>').prop('id', 'target-node')
+    $('body').append(targetNode)
+
+    // now let's beam the template to the target
+    withRenderedTemplate('dest', {destination: targetNode.get(0)}, (el) => {
+      isBeamed(el, '#target-node', '#test-target-id')
+      done()
+    })
+  });
+
+  it ('renders a Template with a given CSS selector as destination', function (done) {
+    // let's create a div with a specific CSS class
+    // and add it to the body
+    const targetNode = $('<div>').addClass('target-node')
+    $('body').append(targetNode)
+
+    // now let's beam the template to the target by CSS selector
+    withRenderedTemplate('dest', {destination: '.target-node'}, (el) => {
+      isBeamed(el, '.target-node', '#test-target-id')
+      done()
+    })
+  });
+
+  it ('renders a Temaplte in the document.body as default destination', function (done) {
+    withRenderedTemplate('dest', {}, (el) => {
+      isBeamed(el, 'body', '#test-target-id')
+      done()
+    })
   });
 });
-
-


### PR DESCRIPTION
The following test suite has been added:

* `meteortesting:mocha` as core testing library
* `practicalmeteor:chai` as asserter library (npm chai is not usable in package tests)
* Template test helpers (taken from the [testing guide](https://guide.meteor.com/testing.html#simple-blaze-unit-test))
* Tests for the three examples from the README
* Updated README on how to run the tests

Benefits:

* open possibility for using a ci provider
* allow to track if anything breaks on further contributions