### PR TITLE
Eventmaps implemented

### DIFF
--- a/src/teleport.js
+++ b/src/teleport.js
@@ -16,15 +16,15 @@ Template.Teleport.onRendered(function () {
 
   // Find the view of the Template where the Teleport has been declared by traversing the view Tree.
   // see: https://github.com/meteor/blaze/blob/c6af95632b1a3f5a7077964e25c9be4ddaf7cc42/packages/blaze/view.js#L9
-  let parentView = this.view.parentView
+  let parentView = this.view.parentView;
   while (parentView.name.indexOf('Template') === -1) {
-    parentView = parentView.parentView
+    parentView = parentView.parentView;
   }
 
   // Connect the parent Template's events and ensure they receive the parents templateInstance as second param
-  this.view.templateContentBlock.__eventMaps = parentView.template.__eventMaps
+  this.view.templateContentBlock.__eventMaps = parentView.template.__eventMaps;
   this.teleported = Blaze.render(this.view.templateContentBlock, parentNode, null, parentView);
-  this.teleported.templateInstance = parentView.templateInstance
+  this.teleported.templateInstance = parentView.templateInstance;
 });
 
 Template.Teleport.onDestroyed(function () {

--- a/src/teleport.js
+++ b/src/teleport.js
@@ -14,7 +14,17 @@ Template.Teleport.onRendered(function () {
     }
   }
 
-  this.teleported = Blaze.render(this.view.templateContentBlock, parentNode);
+  // Find the view of the Template where the Teleport has been declared by traversing the view Tree.
+  // see: https://github.com/meteor/blaze/blob/c6af95632b1a3f5a7077964e25c9be4ddaf7cc42/packages/blaze/view.js#L9
+  let parentView = this.view.parentView
+  while (parentView.name.indexOf('Template') === -1) {
+    parentView = parentView.parentView
+  }
+
+  // Connect the parent Template's events and ensure they receive the parents templateInstance as second param
+  this.view.templateContentBlock.__eventMaps = parentView.template.__eventMaps
+  this.teleported = Blaze.render(this.view.templateContentBlock, parentNode, null, parentView);
+  this.teleported.templateInstance = parentView.templateInstance
 });
 
 Template.Teleport.onDestroyed(function () {

--- a/src/teleport.tests.html
+++ b/src/teleport.tests.html
@@ -1,5 +1,6 @@
 <template name="dest">
 	{{#Teleport destination=destination}}
 	<div id="test-target-id"></div>
+    <button id="click-target">Click</button>
 	{{/Teleport}}
 </template>

--- a/src/teleport.tests.html
+++ b/src/teleport.tests.html
@@ -1,6 +1,6 @@
 <template name="dest">
-	{{#Teleport destination=destination}}
-	<div id="test-target-id"></div>
+  {{#Teleport destination=destination}}
+    <div id="test-target-id"></div>
     <button id="click-target">Click</button>
-	{{/Teleport}}
+  {{/Teleport}}
 </template>

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -65,8 +65,10 @@ describe('teleport to render destination', function () {
     withRenderedTemplate('dest', {}, (el) => {
       const clickTarget = $('#click-target');
       clickTarget.on('click', () => {
-        assert.isTrue(eventMapScoped);
-        done();
+        setTimeout(() => {
+          assert.isTrue(eventMapScoped);
+          done();
+        }, 50)
       });
       // We need to simulate a mouse click
       // on the actual DOM element

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -4,6 +4,15 @@ import { assert } from 'meteor/practicalmeteor:chai';
 import { withRenderedTemplate } from './helpers.tests';
 import './teleport.tests.html';
 
+let eventMapScoped
+
+Template.dest.events({
+  'click #click-target' (event, templateInstance) {
+    event.preventDefault();
+    eventMapScoped = true;
+  }
+})
+
 const isBeamed = (oldTarget, newTarget, selector) => {
   assert.equal($(oldTarget).find(selector).length, 0)
   assert.equal($(newTarget).find(selector).length, 1)
@@ -50,5 +59,18 @@ describe('teleport to render destination', function () {
       isBeamed(el, 'body', '#test-target-id')
       done()
     })
+  });
+
+  it ('keeps the eventmap in scope when rendering to a destination', function (done) {
+    withRenderedTemplate('dest', {}, (el) => {
+      const clickTarget = $('#click-target');
+      clickTarget.on('click', () => {
+        assert.isTrue(eventMapScoped);
+        done();
+      });
+      // We need to simulate a mouse click
+      // on the actual DOM element
+      clickTarget[0].click();
+    });
   });
 });

--- a/src/teleport.tests.js
+++ b/src/teleport.tests.js
@@ -4,7 +4,7 @@ import { assert } from 'meteor/practicalmeteor:chai';
 import { withRenderedTemplate } from './helpers.tests';
 import './teleport.tests.html';
 
-let eventMapScoped
+let eventMapScoped;
 
 Template.dest.events({
   'click #click-target' (event, templateInstance) {
@@ -14,8 +14,8 @@ Template.dest.events({
 })
 
 const isBeamed = (oldTarget, newTarget, selector) => {
-  assert.equal($(oldTarget).find(selector).length, 0)
-  assert.equal($(newTarget).find(selector).length, 1)
+  assert.equal($(oldTarget).find(selector).length, 0);
+  assert.equal($(newTarget).find(selector).length, 1);
 }
 
 describe('teleport to render destination', function () {
@@ -31,33 +31,33 @@ describe('teleport to render destination', function () {
   it ('renders a Template with a given target node as destination', function (done) {
     // let's append a new div to the body
     // which will act as our render target
-    const targetNode = $('<div>').prop('id', 'target-node')
-    $('body').append(targetNode)
+    const targetNode = $('<div>').prop('id', 'target-node');
+    $('body').append(targetNode);
 
     // now let's beam the template to the target
     withRenderedTemplate('dest', {destination: targetNode.get(0)}, (el) => {
-      isBeamed(el, '#target-node', '#test-target-id')
-      done()
+      isBeamed(el, '#target-node', '#test-target-id');
+      done();
     })
   });
 
   it ('renders a Template with a given CSS selector as destination', function (done) {
     // let's create a div with a specific CSS class
     // and add it to the body
-    const targetNode = $('<div>').addClass('target-node')
-    $('body').append(targetNode)
+    const targetNode = $('<div>').addClass('target-node');
+    $('body').append(targetNode);
 
     // now let's beam the template to the target by CSS selector
     withRenderedTemplate('dest', {destination: '.target-node'}, (el) => {
-      isBeamed(el, '.target-node', '#test-target-id')
-      done()
+      isBeamed(el, '.target-node', '#test-target-id');
+      done();
     })
   });
 
   it ('renders a Template in the document.body as default destination', function (done) {
     withRenderedTemplate('dest', {}, (el) => {
-      isBeamed(el, 'body', '#test-target-id')
-      done()
+      isBeamed(el, 'body', '#test-target-id');
+      done();
     })
   });
 


### PR DESCRIPTION
After reading through the gh code of the Blaze repo I found that I can traverse the `parentView` tree upwards until I find the surrounding Template. So no additional parameters required.

The good thing is that there is always a parent Template to be found, so there should be no case where the `while` loop is causing an infinite.

To be on the safe side I could add a counter and throw an Error if it reaches the 10000 or so. What do you think?

Once the parent view has been found we can access it's Template with the `__eventMaps` property and assign it to the contentBlock.

Finally we assign the parent views `templateInstance` to the newly created view. Otherwise the second parameter in the event callback would not have the scope of our parent Template's instance.

I could not write a test to check for the proper `templateInstance` within the `Template.dest.events` part, mainly because I get circular errors and I think this is due to the test environment. What do you think?
